### PR TITLE
Add gallery index with detail view and magnifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "react": "^16.10.1",
     "react-dom": "^16.10.1",
+    "react-router-dom": "5",
     "react-scripts": "3.1.2"
   },
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -1,13 +1,172 @@
 .App {
+  min-height: 100vh;
+}
+
+/* ── Gallery ── */
+
+.gallery {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 40px;
+}
+
+.gallery-header {
+  padding: 48px 0 40px;
   text-align: center;
 }
 
-.App-header {
+.gallery-header h1 {
+  font-size: 28px;
+  font-weight: 400;
+  margin: 0 0 8px;
+  letter-spacing: 0.02em;
+}
+
+.gallery-header a {
+  font-size: 14px;
+  color: #888;
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 40px 32px;
+  padding-bottom: 80px;
+}
+
+.gallery-item {
+  display: block;
+  text-align: center;
+}
+
+.gallery-item-img-wrapper {
+  aspect-ratio: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  background: #fafafa;
+}
+
+.gallery-item-img-wrapper img {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  transition: opacity 0.3s ease;
+}
+
+.gallery-item:hover .gallery-item-img-wrapper img {
+  opacity: 0.85;
+}
+
+.gallery-item-title {
+  margin-top: 12px;
+  font-size: 15px;
+  color: #555;
+}
+
+/* ── Painting page ── */
+
+.painting-page {
   min-height: 100vh;
+}
+
+.painting-header {
+  padding: 24px 40px;
+}
+
+.back-link {
+  font-size: 20px;
+  font-weight: 400;
+  letter-spacing: 0.02em;
+}
+
+.painting-container {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 1.5vmin);
+  padding: 20px 40px 80px;
+}
+
+.painting-img-wrapper {
+  position: relative;
+  cursor: crosshair;
+  display: inline-block;
+  line-height: 0;
+}
+
+.painting-img {
+  max-height: calc(100vh - 200px);
+  max-width: calc(100vw - 80px);
+  height: auto;
+}
+
+.magnifier-lens {
+  position: fixed;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15), 0 4px 20px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+  z-index: 100;
+}
+
+.painting-info {
+  text-align: center;
+  margin-top: 32px;
+}
+
+.painting-title {
+  font-size: 18px;
+}
+
+.painting-nav {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  max-width: 600px;
+  margin-top: 40px;
+  font-size: 15px;
+}
+
+.nav-link {
+  color: #888;
+  transition: color 0.2s;
+}
+
+.nav-link:hover {
   color: #333;
+}
+
+/* ── Responsive ── */
+
+@media (max-width: 600px) {
+  .gallery {
+    padding: 0 20px;
+  }
+
+  .gallery-grid {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 24px 16px;
+  }
+
+  .gallery-header {
+    padding: 32px 0 24px;
+  }
+
+  .painting-header {
+    padding: 16px 20px;
+  }
+
+  .painting-container {
+    padding: 10px 20px 60px;
+  }
+
+  .painting-img {
+    max-width: calc(100vw - 40px);
+  }
+
+  .painting-nav {
+    font-size: 14px;
+    gap: 16px;
+  }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,40 +1,19 @@
 import React from "react";
+import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import "./App.css";
-import images from "./data/images";
-
-console.log(images);
+import Gallery from "./Gallery";
+import PaintingPage from "./PaintingPage";
 
 function App() {
   return (
-    <div className="App">
-      <h1>Gustavo Saiani</h1>
-      <a href="mailto:gs@gustavosaiani.com">gs@gustavosaiani.com</a>
-      <header className="App-header">
-        {images.data
-          .filter(image => image.visible)
-          .map((image, index) => (
-            <div style={{ marginBottom: "60px" }}>
-              <img
-                alt={image.name}
-                id={image.slug}
-                src={`https://s3-sa-east-1.amazonaws.com/gustavosaiani.com/large/${
-                  image.filename
-                }`}
-                loading={index > 1 ? "lazy" : ""}
-              />
-              <div>
-                <p>
-                  <b>{image.name}</b>, {image.date}
-                </p>
-                <p>{image.material}</p>
-                <p>
-                  {image.height} × {image.width}cm
-                </p>
-              </div>
-            </div>
-          ))}
-      </header>
-    </div>
+    <Router>
+      <div className="App">
+        <Switch>
+          <Route exact path="/" component={Gallery} />
+          <Route path="/work/:slug" component={PaintingPage} />
+        </Switch>
+      </div>
+    </Router>
   );
 }
 

--- a/src/Gallery.js
+++ b/src/Gallery.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import images from "./data/images";
+
+const S3_BASE = "https://s3-sa-east-1.amazonaws.com/gustavosaiani.com";
+
+const visibleImages = images.data
+  .filter(image => image.visible)
+  .sort((a, b) => a.position - b.position);
+
+function Gallery() {
+  return (
+    <div className="gallery">
+      <header className="gallery-header">
+        <h1>Gustavo Saiani</h1>
+        <a href="mailto:gs@gustavosaiani.com">gs@gustavosaiani.com</a>
+      </header>
+      <div className="gallery-grid">
+        {visibleImages.map(image => (
+          <Link
+            key={image.slug}
+            to={`/work/${image.slug}`}
+            className="gallery-item"
+          >
+            <div className="gallery-item-img-wrapper">
+              <img
+                alt={image.name}
+                src={`${S3_BASE}/thumbnails/${image.filename}`}
+                loading="lazy"
+              />
+            </div>
+            <p className="gallery-item-title">{image.name}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default Gallery;

--- a/src/PaintingPage.js
+++ b/src/PaintingPage.js
@@ -1,0 +1,126 @@
+import React, { useState, useRef, useCallback } from "react";
+import { Link, useParams } from "react-router-dom";
+import images from "./data/images";
+
+const S3_BASE = "https://s3-sa-east-1.amazonaws.com/gustavosaiani.com";
+const ZOOM = 2.5;
+const LENS_SIZE = 200;
+
+function PaintingPage() {
+  const { slug } = useParams();
+  const image = images.data.find(img => img.slug === slug);
+  const imgRef = useRef(null);
+  const [lens, setLens] = useState({ active: false, x: 0, y: 0, bgX: 0, bgY: 0 });
+
+  const handleMouseMove = useCallback(e => {
+    const img = imgRef.current;
+    if (!img) return;
+    const rect = img.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+
+    // Position lens centered on cursor
+    const lensLeft = e.clientX - LENS_SIZE / 2;
+    const lensTop = e.clientY - LENS_SIZE / 2;
+
+    // Background position for zoomed image
+    const bgX = -(x * ZOOM - LENS_SIZE / 2);
+    const bgY = -(y * ZOOM - LENS_SIZE / 2);
+
+    setLens({
+      active: true,
+      left: lensLeft,
+      top: lensTop,
+      bgX,
+      bgY,
+      imgWidth: rect.width * ZOOM,
+      imgHeight: rect.height * ZOOM,
+    });
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setLens(prev => ({ ...prev, active: false }));
+  }, []);
+
+  if (!image) {
+    return (
+      <div className="painting-page">
+        <header className="painting-header">
+          <Link to="/" className="back-link">Gustavo Saiani</Link>
+        </header>
+        <p>Work not found.</p>
+      </div>
+    );
+  }
+
+  const largeSrc = `${S3_BASE}/large/${image.filename}`;
+
+  // Find prev/next for navigation
+  const visible = images.data
+    .filter(img => img.visible)
+    .sort((a, b) => a.position - b.position);
+  const currentIndex = visible.findIndex(img => img.slug === slug);
+  const prev = currentIndex > 0 ? visible[currentIndex - 1] : null;
+  const next = currentIndex < visible.length - 1 ? visible[currentIndex + 1] : null;
+
+  return (
+    <div className="painting-page">
+      <header className="painting-header">
+        <Link to="/" className="back-link">Gustavo Saiani</Link>
+      </header>
+
+      <div className="painting-container">
+        <div
+          className="painting-img-wrapper"
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+        >
+          <img
+            ref={imgRef}
+            alt={image.name}
+            src={largeSrc}
+            className="painting-img"
+          />
+          {lens.active && (
+            <div
+              className="magnifier-lens"
+              style={{
+                left: lens.left,
+                top: lens.top,
+                width: LENS_SIZE,
+                height: LENS_SIZE,
+                backgroundImage: `url(${largeSrc})`,
+                backgroundPosition: `${lens.bgX}px ${lens.bgY}px`,
+                backgroundSize: `${lens.imgWidth}px ${lens.imgHeight}px`,
+                backgroundRepeat: "no-repeat",
+              }}
+            />
+          )}
+        </div>
+
+        <div className="painting-info">
+          <p className="painting-title">
+            <b>{image.name}</b>, {image.date}
+          </p>
+          <p>{image.material}</p>
+          <p>{image.height} × {image.width}cm</p>
+        </div>
+
+        <nav className="painting-nav">
+          {prev ? (
+            <Link to={`/work/${prev.slug}`} className="nav-link">← {prev.name}</Link>
+          ) : (
+            <span />
+          )}
+          {next ? (
+            <Link to={`/work/${next.slug}`} className="nav-link">{next.name} →</Link>
+          ) : (
+            <span />
+          )}
+        </nav>
+      </div>
+    </div>
+  );
+}
+
+export default PaintingPage;

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,17 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
- font-family:  Garamond, Georgia, Cambria, serif, ui-serif, "Times New Roman", Times;
- margin: 0;
+  font-family: Garamond, Georgia, Cambria, serif, ui-serif, "Times New Roman", Times;
+  margin: 0;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color: #333;
 }
 
 a {
-  color: black;
-  display: block;
-  font-size: 14px;
-  padding: 10px 0 100px;
+  color: inherit;
   text-decoration: none;
 }
 
@@ -17,29 +19,7 @@ a:hover {
   text-decoration: underline;
 }
 
-code {
-  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New",
-    monospace;
-}
-
-h1 {
-  font-size: 24px;
-  font-weight: 400;
-  margin: 20px 0 0;
-}
-
-img {
-  height: auto;
-  margin-bottom: 24px;
-  max-height: calc(100vh - 140px);
-  max-width: 100vw;
-}
-
 p {
-  font-size: 18px;
-  margin: 0 0 10px;
-}
-
-p + img {
-  margin-top: 240px;
+  font-size: 16px;
+  margin: 0 0 6px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,6 +909,11 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.1.2", "@babel/runtime@^7.12.13":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
+  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
+
 "@babel/template@^7.1.0", "@babel/template@^7.2.2":
   version "7.2.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
@@ -4689,6 +4694,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4697,6 +4714,13 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
+
+hoist-non-react-statics@^3.1.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -6153,7 +6177,7 @@ loglevel@^1.4.1:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.1.tgz#e0fc95133b6ef276cdc8887cdaf24aa6f156f8fa"
   integrity sha1-4PyVEztu8nbNyIh82vJKpvFW+Po=
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7147,6 +7171,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -8229,6 +8260,11 @@ react-error-overlay@^6.0.2:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.2.tgz#642bd6157c6a4b6e9ca4a816f7ed30b868c47f81"
   integrity sha512-DHRuRk3K4Lg9obI6J4Y+nKvtwjasYRU9CFL3ud42x9YJG1HbQjSNublapC/WBJOA726gNUbqbj0U2df9+uzspQ==
 
+react-is@^16.6.0, react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
 react-is@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"
@@ -8238,6 +8274,34 @@ react-is@^16.8.4:
   version "16.10.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.1.tgz#0612786bf19df406502d935494f0450b40b8294f"
   integrity sha512-BXUMf9sIOPXXZWqr7+c5SeOKJykyVr2u0UDzEf4LNGc6taGkQe1A9DFD07umCIXz45RLr9oAAwZbAJ0Pkknfaw==
+
+react-router-dom@5:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.4.tgz#2ed62ffd88cae6db134445f4a0c0ae8b91d2e5e6"
+  integrity sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.3.4"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.4.tgz#8ca252d70fcc37841e31473c7a151cf777887bb5"
+  integrity sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@3.1.2:
   version "3.1.2"
@@ -8583,6 +8647,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@3.1.0:
   version "3.1.0"
@@ -9576,6 +9645,16 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
+tiny-invariant@^1.0.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
+  integrity sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==
+
+tiny-warning@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -9923,6 +10002,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Summary
- Replace single-page scroll layout with a thumbnail grid homepage and individual painting detail pages
- Home loads thumbnails from S3 `/thumbnails/` for faster page loads; large images only load on detail view
- Hovering over a painting shows a 2.5× circular magnifier lens
- Prev/next navigation between works on the detail page
- Responsive layout for mobile

## Test plan
- [ ] Verify thumbnail grid renders on homepage
- [ ] Click a painting and confirm detail page loads with large image
- [ ] Hover over painting to test magnifier lens
- [ ] Test prev/next navigation between works
- [ ] Test mobile responsiveness
- [ ] Verify back link returns to gallery